### PR TITLE
Adding support for ppc64le platform

### DIFF
--- a/PLATFORMS
+++ b/PLATFORMS
@@ -1,1 +1,1 @@
-linux/amd64
+linux/amd64,linux/ppc64le


### PR DESCRIPTION
This change will allow publishing multi-arch image with ppc64le support.