### PR TITLE
Disabling updates check

### DIFF
--- a/config/etc/default/jetbrains/updates.xml
+++ b/config/etc/default/jetbrains/updates.xml
@@ -1,0 +1,5 @@
+<application>
+  <component name="UpdatesConfigurable">
+    <option name="CHECK_NEEDED" value="false" />
+  </component>
+</application>

--- a/scripts/preliminary-configuration.sh
+++ b/scripts/preliminary-configuration.sh
@@ -13,4 +13,5 @@ if [ ! -e ${JETBRAINS_BASE_MOUNT_FOLDER}/${JETBRAINS_PRODUCT}/config/options ]; 
     echo "Provide preliminary configuration for JetBrains product."
     cp /etc/default/jetbrains/other.xml ${JETBRAINS_BASE_MOUNT_FOLDER}/${JETBRAINS_PRODUCT}/config/options/other.xml
     cp /etc/default/jetbrains/ide.general.xml ${JETBRAINS_BASE_MOUNT_FOLDER}/${JETBRAINS_PRODUCT}/config/options/ide.general.xml
+    cp /etc/default/jetbrains/updates.xml ${JETBRAINS_BASE_MOUNT_FOLDER}/${JETBRAINS_PRODUCT}/config/options/updates.xml
 fi


### PR DESCRIPTION
This changes proposal provide preliminary configuration to disable automatic updates check, because in runtime it is impossible to update JetBrains products.

Fixes https://github.com/eclipse/che/issues/18305

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>