### PR TITLE
Add missed libraries which is required for markdown plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG PRODUCT_VERSION="2020.2.3"
 ARG BASE_MOUNT_FOLDER="/JetBrains"
 
 # which is used by novnc to find websockify
-RUN yum install -y tigervnc-server supervisor wget java-11-openjdk-devel novnc fluxbox git which
+RUN yum install -y tigervnc-server supervisor wget java-11-openjdk-devel novnc fluxbox git which nss libXScrnSaver mesa-libgbm
 
 RUN mkdir /${PRODUCT_NAME}-${PRODUCT_VERSION} && \
     case ${PRODUCT_NAME} in \


### PR DESCRIPTION
This changes proposal provides additional system libraries that are needed for markdown plugin bundled with JetBrains products.

Fixes https://github.com/eclipse/che/issues/18336

Opened markdown file in editor with installed libraries:
![71595739cc5e:0 () - noVNC 2020-11-11 12-20-23](https://user-images.githubusercontent.com/1968177/98799858-56435380-2418-11eb-9d37-835a7fc55efc.jpg)

State without installed libraries:
![8e309d90c493:0 () - noVNC 2020-11-11 12-23-18](https://user-images.githubusercontent.com/1968177/98800290-dc5f9a00-2418-11eb-8bc6-48db8668a762.jpg)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>