### PR TITLE
PRJ-241: Single host environment support

### DIFF
--- a/patches/projector-client/PRJ-241.patch
+++ b/patches/projector-client/PRJ-241.patch
@@ -1,0 +1,13 @@
+diff --git a/projector-client-common/src/jsMain/kotlin/org/jetbrains/projector/client/common/misc/ParamsProvider.kt b/projector-client-common/src/jsMain/kotlin/org/jetbrains/projector/client/common/misc/ParamsProvider.kt
+index 560ce9a..bbe78a6 100644
+--- a/projector-client-common/src/jsMain/kotlin/org/jetbrains/projector/client/common/misc/ParamsProvider.kt
++++ b/projector-client-common/src/jsMain/kotlin/org/jetbrains/projector/client/common/misc/ParamsProvider.kt
+@@ -31,7 +31,7 @@ actual object ParamsProvider {
+   private fun getCurrentHostname(): String = when (val hostname = window.location.hostname) {
+     "" -> "localhost"  // when you open a file in a browser (like "file://..."), the hostname is empty, so assume the localhost is preferred
+ 
+-    else -> hostname
++    else -> "$hostname${if (window.location.pathname != "/") window.location.pathname else ""}"
+   }
+ 
+   private fun getCurrentPort(): String {


### PR DESCRIPTION
This changes proposal adds an ability to run Projector Client under single host environment, where Projector Server is configured behind the proxy.

Proposed upstream changes: https://youtrack.jetbrains.com/issue/PRJ-241#focus=Comments-27-4847282.0-0

fixes https://github.com/eclipse/che/issues/19577

Linked upstream issues:

- https://youtrack.jetbrains.com/issue/PRJ-241
- https://youtrack.jetbrains.com/issue/PRJ-386

To test the PR. It is enough to create the workspace on https://workspaces.openshift.com/
```yaml
apiVersion: 1.0.0
metadata:
  name: projector-idea-c
components:
  - type: cheEditor
    reference: 'https://gist.github.com/vzhukovs/dc20ff958b8aa2f25a91fdfc8ca3aad0/raw/01fa1b70c4c2ff8842010ab6b7fcac8f0d68ab7d/che-idea.meta.yaml'
    alias: projector-idea-c
```

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>