### PR TITLE
Include socat in runtime image and synchronize ide launcher with upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ ENV HOME /home/$PROJECTOR_USER_NAME
 ENV PROJECTOR_CONFIG_DIR $HOME/.config
 RUN set -ex \
     && microdnf install -y --nodocs \
-    shadow-utils wget git nss procps findutils \
+    shadow-utils wget git nss procps findutils which socat \
     # Packages required by JetBrains products.
     libsecret jq \
     # Packages needed for AWT.

--- a/static/ide-projector-launcher.sh
+++ b/static/ide-projector-launcher.sh
@@ -28,6 +28,8 @@ for i in "${!ideRunnerCandidates[@]}"; do
         unset 'ideRunnerCandidates[i]'
     elif [[ ${ideRunnerCandidates[i]} = *"projector"* ]]; then
         unset 'ideRunnerCandidates[i]'
+    elif [[ ${ideRunnerCandidates[i]} = *"game-tools.sh" ]]; then
+        unset 'ideRunnerCandidates[i]'
     fi
 done
 


### PR DESCRIPTION
Current change proposal adds necessary tools needed to operate with tcp connections needed for support Android Studio according to https://github.com/eclipse/che/issues/19575. Also synchronize `ide-projector-launcher.sh` with upstream to allow run Android Studio inside the image.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>