### PR TITLE
Set IDE window maximized at initialization step

### DIFF
--- a/clone-projector.sh
+++ b/clone-projector.sh
@@ -33,7 +33,7 @@ base_dir=$(cd "$(dirname "$0")"; pwd)
 # Clone the Projector Client, stick to the particular version and apply necessary patches if needed
 git clone https://github.com/JetBrains/projector-client.git "$base_dir"/../projector-client
 cd "$base_dir"/../projector-client
-git checkout 58de0040e2fa8e9bd9e82bd0c5faa3274b03c0fb
+git checkout 555e38b5885df2598fcd2639c687124e60e3218e
 
 if [ -d "$base_dir/patches/projector-client" ]; then
     echo "Applying patches for Projector Client"
@@ -46,7 +46,7 @@ cd "$base_dir"
 # Link with Projector Client
 git clone https://github.com/JetBrains/projector-server.git "$base_dir"/../projector-server
 cd "$base_dir"/../projector-server
-git checkout tags/v1.1.2 -b v1.1.2
+git checkout f8461f8aadefcdc2ebf3ceb97cf591df1e6d2f8f
 echo "useLocalProjectorClient=true" > local.properties
 
 if [ -d "$base_dir/patches/projector-server" ]; then

--- a/patches/projector-client/PRJ-452.patch
+++ b/patches/projector-client/PRJ-452.patch
@@ -1,0 +1,50 @@
+diff --git a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/Window.kt b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/Window.kt
+index 0bf358a..d5c630a 100644
+--- a/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/Window.kt
++++ b/projector-client-web/src/main/kotlin/org/jetbrains/projector/client/web/window/Window.kt
+@@ -24,6 +24,7 @@
+ package org.jetbrains.projector.client.web.window
+ 
+ import kotlinx.browser.document
++import kotlinx.browser.window
+ import kotlinx.dom.addClass
+ import org.jetbrains.projector.client.common.DrawEvent
+ import org.jetbrains.projector.client.common.SingleRenderingSurfaceProcessor
+@@ -37,10 +38,12 @@ import org.jetbrains.projector.client.web.state.ClientAction
+ import org.jetbrains.projector.client.web.state.ClientStateMachine
+ import org.jetbrains.projector.client.web.state.LafListener
+ import org.jetbrains.projector.client.web.state.ProjectorUI
++import org.jetbrains.projector.common.protocol.data.CommonIntSize
+ import org.jetbrains.projector.common.protocol.data.CommonRectangle
+ import org.jetbrains.projector.common.protocol.data.CursorType
+ import org.jetbrains.projector.common.protocol.toClient.WindowData
+ import org.jetbrains.projector.common.protocol.toClient.WindowType
++import org.jetbrains.projector.common.protocol.toServer.ClientResizeEvent
+ import org.jetbrains.projector.common.protocol.toServer.ClientWindowCloseEvent
+ import org.jetbrains.projector.common.protocol.toServer.ClientWindowMoveEvent
+ import org.jetbrains.projector.common.protocol.toServer.ClientWindowResizeEvent
+@@ -118,6 +121,7 @@ class Window(windowData: WindowData, private val stateMachine: ClientStateMachin
+ 
+     if (windowData.windowType == WindowType.IDEA_WINDOW || windowData.windowType == WindowType.POPUP) {
+       canvas.style.border = "none"
++      setMaximized()
+     }
+     else if (windowData.windowType == WindowType.WINDOW) {
+       if (windowData.undecorated) {
+@@ -248,6 +252,16 @@ class Window(windowData: WindowData, private val stateMachine: ClientStateMachin
+     )
+   }
+ 
++  private fun setMaximized() {
++    val userScalingRatio = ParamsProvider.USER_SCALING_RATIO
++
++    stateMachine.fire(ClientAction.AddEvent(ClientResizeEvent(size = CommonIntSize(
++      width = (window.innerWidth / userScalingRatio).roundToInt(),
++      height = (window.innerHeight / userScalingRatio).roundToInt()
++    ))))
++    stateMachine.fire(ClientAction.WindowResize)
++  }
++
+   fun dispose() {
+     canvas.remove()
+     border.dispose()


### PR DESCRIPTION
Set `IDEA_WINDOW` window type maximized at initialization step. Patch fix for https://youtrack.jetbrains.com/issue/PRJ-452
Related discussion: https://youtrack.jetbrains.com/issue/PRJ-452#focus=Comments-27-4861019.0-0

fixes: https://github.com/eclipse/che/issues/19595

Now after workspace create, the IDE window is maximized:

![Eclipse Che 2021-04-30 13-47-18](https://user-images.githubusercontent.com/1968177/116685246-b0ca6f00-a9ba-11eb-9f6b-e23c7a40743c.jpg)


Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>