### PR TITLE
Use correct version of Python 3 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN set -ex \
     && microdnf install -y --nodocs \
     shadow-utils wget git nss procps findutils which socat \
     # Packages required by JetBrains products.
-    libsecret jq java-11-openjdk-devel python2 python3 python3-pip python3-setuptools \
+    libsecret jq java-11-openjdk-devel python2 python39 \
     # Packages needed for AWT.
     libXext libXrender libXtst libXi libX11-xcb mesa-libgbm libdrm freetype \
     && adduser -r -u 1002 -G root -d $HOME -m -s /bin/sh $PROJECTOR_USER_NAME \


### PR DESCRIPTION
Use `python39` instead `python3` which caused build problem due to unresolved dependencies. Get rid of `python3-pip` and `python3-setuptools` as far as these packages are included in `python39`.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>