### PR TITLE
Build images in Brew compliant way

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 **
 
-!/projector-client/**
-!/projector-server/**
-!/jetbrains-editor-images/static/**
+!/build/ide-packaging
+!/build/projector-server-assembly
+!/static/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
               --log-level debug
       - name: Provide release asset path
         id: release_asset_path
-        run: echo ::set-output name=path::build/$(basename ${{ matrix.downloadUrl }})
+        run: echo ::set-output name=path::build/docker/$(basename ${{ matrix.downloadUrl }})
       - name: Provide release asset name
         id: release_asset_name
         run: echo ::set-output name=name::${{ steps.tag_name.outputs.sourceTag }}-$(basename ${{ matrix.downloadUrl }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ This document reflects the project's changes made after each release cycle
 
 - Removed auxiliary patch to support single host environment
 
+- Build community images in Brew compliant way. ([#40](https://github.com/che-incubator/jetbrains-editor-images/pull/40))
+
+  To be a part of Codeready Workspaces there are some important changes come:
+
+  - Projector Build performed only on the host machine, **not inside the container**. To build the Projector Client and Projector Server it is only enough to have at least JDK 11 and configured environment variable `JAVA_HOME`.
+
+  - IDE downloads to the host machine, **not inside the container**. This allows to apply caching mechanism to speedup the image build from ~5-6 minutes to 1-2 minutes.
+
+  - Changed `compatible-ide.json` configuration by using the CDN links to have ability to cache downloaded packages.
+
+  - [Internal] Removed build arguments from the Dockerfile. So to build the image performs as usual, by calling `./projector.sh build`.
+
+  - Removed `--projector-only` parameter and introduced `--prepare` instead. This parameter will perform all necessary work to prepare the assembly before Docker build. So calling:
+
+    ```sh
+    $ ./projector.sh build --prepare
+    ```
+
+    will prepare Projector Server and Projector Client sources, download the IDE packaging and omit the Docker build step. Then Docker image can be simply built by calling:
+
+    ```sh
+    $ DOCKER_BUILDKIT=1 docker build --progress=auto -t <image_name> -f Dockerfile .
+    ```
+
+  - Removed `--no-projector-build` parameter. As far as Projector Server and Projector Client builds only on the host machine.
+
 ### Added
 
 - TBD

--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ the predefined IDE packaging from the default configuration.
 Options:
   -t, --tag string              Name and optionally a tag in the 'name:tag' format for the result image
   -u, --url string              Downloadable URL of IntelliJ-based IDE package
-      --no-projector-build      Skip build of Projector Client and Projector Server inside the container
       --run-on-build            Run the container immediately after build
       --save-on-build           Save the image to a tar archive after build. Basename of --url.
       --mount-volumes [string]  Mount volumes to the container which was started using '--run-on-build' option
@@ -176,8 +175,10 @@ Options:
                                 Default value: $HOME/projector-user:/home/projector-user,$HOME/projector-projects:/projects
   -p, --progress string         Set type of progress output ("auto"|"plain") (default "auto")
       --config string           Specify the configuration file for predefined IDE package list (default "compatible-ide.json")
-      --projector-only          Clone and build Projector only ignoring other options. Used when need to fetch Projector
-                                sources only and assembly the binaries.
+      --prepare                 Clone and build Projector only ignoring other options. Also downloads the IDE packaging
+                                by the --url option. If --url option is omitted then interactive wizard is called to choose
+                                the right packaging to prepare. Used when need to fetch Projector sources only, assembly
+                                the binaries and download the IDE packaging.
 ```
 
 

--- a/compatible-ide.json
+++ b/compatible-ide.json
@@ -6,17 +6,17 @@
     "productVersion": [
       {
         "version": "2020.3.3",
-        "downloadUrl": "https://download.jetbrains.com/idea/ideaIC-2020.3.3.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/idea/ideaIC-2020.3.3.tar.gz",
         "latest": true
       },
       {
         "version": "2020.3.2",
-        "downloadUrl": "https://download.jetbrains.com/idea/ideaIC-2020.3.2.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/idea/ideaIC-2020.3.2.tar.gz",
         "latest": false
       },
       {
         "version": "2020.3.1",
-        "downloadUrl": "https://download.jetbrains.com/idea/ideaIC-2020.3.1.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/idea/ideaIC-2020.3.1.tar.gz",
         "latest": false
       }
     ]
@@ -28,32 +28,32 @@
     "productVersion": [
       {
         "version": "2020.3.5",
-        "downloadUrl": "https://download.jetbrains.com/python/pycharm-community-2020.3.5.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/python/pycharm-community-2020.3.5.tar.gz",
         "latest": true
       },
       {
         "version": "2020.3.4",
-        "downloadUrl": "https://download.jetbrains.com/python/pycharm-community-2020.3.4.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/python/pycharm-community-2020.3.4.tar.gz",
         "latest": false
       },
       {
         "version": "2020.3.3",
-        "downloadUrl": "https://download.jetbrains.com/python/pycharm-community-2020.3.3.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/python/pycharm-community-2020.3.3.tar.gz",
         "latest": false
       },
       {
         "version": "2020.3.2",
-        "downloadUrl": "https://download.jetbrains.com/python/pycharm-community-2020.3.2.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/python/pycharm-community-2020.3.2.tar.gz",
         "latest": false
       },
       {
         "version": "2020.3.1",
-        "downloadUrl": "https://download.jetbrains.com/python/pycharm-community-2020.3.1.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/python/pycharm-community-2020.3.1.tar.gz",
         "latest": false
       },
       {
         "version": "2020.3",
-        "downloadUrl": "https://download.jetbrains.com/python/pycharm-community-2020.3.tar.gz",
+        "downloadUrl": "https://download-cdn.jetbrains.com/python/pycharm-community-2020.3.tar.gz",
         "latest": false
       }
     ]

--- a/make-release.sh
+++ b/make-release.sh
@@ -13,7 +13,7 @@ base_dir=$(cd "$(dirname "$0")" || exit; pwd)
 
 RELEASE_TAG=
 PROJECTOR_CLI_LOG_LEVEL=info
-BUILD_DIRECTORY="$base_dir"/build
+BUILD_DIRECTORY="$base_dir"/build/docker
 SKIP_CHECKS=false
 
 # Logging configuration
@@ -181,7 +181,7 @@ if [ $SKIP_CHECKS == false ]; then
     .log 7 "Check if build directory '$BUILD_DIRECTORY' exists"
     if [ ! -e "$BUILD_DIRECTORY" ]; then
       .log 7 "Creating build directory '$BUILD_DIRECTORY'"
-      mkdir "$BUILD_DIRECTORY"
+      mkdir -p "$BUILD_DIRECTORY"
     fi
     .log 7 "Build directory '$BUILD_DIRECTORY' exists"
 


### PR DESCRIPTION
Build community images in Brew compliant way.

Need for https://issues.redhat.com/browse/CRW-1587

  - Projector Build performed only on the host machine, **not inside the container**. To build the Projector Client and Projector Server it is only enough to have at least JDK 11 and configured environment variable `JAVA_HOME`.

  - IDE downloads to the host machine, **not inside the container**. This allows to apply caching mechanism to speedup the image build from ~5-6 minutes to 1-2 minutes.

  - Changed `compatible-ide.json` configuration by using the CDN links to have ability to cache downloaded packages.

  - [Internal] Removed build arguments from the Dockerfile. So to build the image performs as usual, by calling `./projector.sh build`.

  - Removed `--projector-only` parameter and introduced `--prepare` instead. This parameter will perform all necessary work to prepare the assembly before Docker build. So calling:

    ```sh
    $ ./projector.sh build --prepare
    ```

    will prepare Projector Server and Projector Client sources, download the IDE packaging and omit the Docker build step. Then Docker image can be simply built by calling:

    ```sh
    $ DOCKER_BUILDKIT=1 docker build --progress=auto -t <image_name> -f Dockerfile .
    ```

  - Removed `--no-projector-build` parameter. As far as Projector Server and Projector Client builds only on the host machine.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>