### PR TITLE
Prepare Dockerfile to build in OSBS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 **
 
-!/build/ide-packaging
-!/build/projector-server-assembly
-!/static/**
+!/ide-packaging
+!/projector-server-assembly
+!/static-assembly

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .idea
 *.iml
-*.tar.gz
 build
+ide-packaging
+projector-server-assembly
+static-assembly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This document reflects the project's changes made after each release cycle
 
 ### Changed
 
-- TBD
+- Prepare Dockerfile to build in OSBS ([#43](https://github.com/che-incubator/jetbrains-editor-images/pull/43))
 
 ### Fixed
 

--- a/projector.sh
+++ b/projector.sh
@@ -25,8 +25,9 @@ RUN_ON_BUILD=false
 SAVE_ON_BUILD=false
 SAVE_ON_BUILD_DIRECTORY="$BUILD_DIRECTORY"/docker
 IDE_PACKAGING_DIRECTORY="$BUILD_DIRECTORY"/ide
-CURRENT_IDE_PACKAGING_SYMLINK="$BUILD_DIRECTORY"/ide-packaging
-CURRENT_PROJECTOR_ASSEMBLY_SYMLINK="$BUILD_DIRECTORY"/projector-server-assembly
+CURRENT_IDE_PACKAGING_SYMLINK="$base_dir"/ide-packaging
+CURRENT_PROJECTOR_ASSEMBLY_SYMLINK="$base_dir"/projector-server-assembly
+CURRENT_PROJECTOR_STATIC_ASSEMBLY="$base_dir"/static-assembly
 PROGRESS=auto
 CONFIG_JSON=compatible-ide.json
 CONFIG_JSON_PATH="$base_dir"/"$CONFIG_JSON"
@@ -347,6 +348,18 @@ runOnBuild() {
   fi
 }
 
+prepareStaticFiles() {
+  cd "$base_dir" || exit 1
+  .log 7 "Current working directory '$(pwd)'"
+  if [ -f "$CURRENT_PROJECTOR_STATIC_ASSEMBLY" ]; then
+    .log 7 "Removing symlink '$CURRENT_PROJECTOR_STATIC_ASSEMBLY'"
+    rm "$CURRENT_PROJECTOR_STATIC_ASSEMBLY"
+  fi
+
+  .log 7 "Creating archive for Projector static files '$CURRENT_PROJECTOR_STATIC_ASSEMBLY'"
+  tar -czf "$CURRENT_PROJECTOR_STATIC_ASSEMBLY" static
+}
+
 prepareAssembly() {
   if [ -z "$URL" ]; then
     .log 7 "Ignoring --tag and --url option"
@@ -355,6 +368,7 @@ prepareAssembly() {
     # Run interactive wizard to choose IDE packaging from predefined configuration
     selectPackagingFromPredefinedConfig
   fi
+  prepareStaticFiles
   downloadIdePackaging
   checkProjectorSourcesExist
   projectorBuild
@@ -393,6 +407,7 @@ buildContainerImage() {
     selectPackagingFromPredefinedConfig
   fi
 
+  prepareStaticFiles
   downloadIdePackaging
   checkProjectorSourcesExist
   projectorBuild


### PR DESCRIPTION
Current changes proposal prepare Dockerfile build in OSBS. Unify build step for Community and CRW image versions.

- Changed `ADD` instructions to `COPY` to reduce `sed` calls in synchronisation scripts in `codeready-wroskapces-images` repository.
- Archive `static/` folder and provide to Dockerfile as `static-assembly`. This need because `rhpkg` utility doesn't support folders as source artifact.
- Added functions to `./projector.sh` to prepare archive for `static/` folder.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>