### PR TITLE
Change asset's names according to brew conventions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-**
-
-!/ide-packaging
-!/projector-server-assembly
-!/static-assembly
+!/asset-ide-packaging.tar.gz
+!/asset-projector-server-assembly.zip
+!/asset-static-assembly.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 .idea
 *.iml
 build
-ide-packaging
-projector-server-assembly
-static-assembly
+asset-ide-packaging.tar.gz
+asset-projector-server-assembly.zip
+asset-static-assembly.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,11 @@
 # Changelog
 This document reflects the project's changes made after each release cycle
 
-## [YYYYMMDD] Unreleased
-
-### News
-
-- TBD
-
-### Added
-
-- TBD
+## [20210728]
 
 ### Changed
 
-- TBD
-
-### Fixed
-
-- TBD
+- Change asset's names according to brew conventions ([#46](https://github.com/che-incubator/jetbrains-editor-images/pull/46))
 
 ## [20210727]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,30 +26,30 @@
 #   $ ./projector.sh build [OPTIONS]
 
 # Stage 1. Prepare JetBrains IDE with Projector.
-#   Requires ide-packaging which should point to the ide packaging downloaded
-#   previously, usually tar.gz archive. Also requires projector-server-assembly
-#   which points to the built Projector Server assembly, zip archive. Requires
-#   static-assembly a gzipped static directory.
+#   Requires the following assets:
+#       * asset-ide-packaging.tar.gz - IDE packaging downloaded previously;
+#       * asset-projector-server-assembly.zip - Projector Server assembly;
+#       * asset-static-assembly.tar.gz - archived `static/` directory.
 FROM registry.access.redhat.com/ubi8-minimal:8.4-205 as projectorAssembly
 ENV PROJECTOR_DIR /projector
-COPY ide-packaging /tmp/ide-unpacked/
-COPY projector-server-assembly $PROJECTOR_DIR/
-COPY static-assembly $PROJECTOR_DIR/
+COPY asset-ide-packaging.tar.gz /tmp/ide-unpacked/
+COPY asset-projector-server-assembly.zip $PROJECTOR_DIR/
+COPY asset-static-assembly.tar.gz $PROJECTOR_DIR/
 RUN set -ex \
     && microdnf install -y --nodocs findutils tar gzip unzip \
     && cd /tmp/ide-unpacked \
-    && tar xf ide-packaging \
-    && rm ide-packaging \
+    && tar xf asset-ide-packaging.tar.gz \
+    && rm asset-ide-packaging.tar.gz \
     && find . -maxdepth 1 -type d -name * -exec mv {} $PROJECTOR_DIR/ide \; \
     && cd $PROJECTOR_DIR \
     && rm -rf /tmp/ide-unpacked \
-    && unzip projector-server-assembly \
-    && rm projector-server-assembly \
+    && unzip asset-projector-server-assembly.zip \
+    && rm asset-projector-server-assembly.zip \
     && find . -maxdepth 1 -type d -name projector-server-* -exec mv {} projector-server \; \
     && mv projector-server ide/projector-server \
     && chmod 644 ide/projector-server/lib/* \
-    && tar -xf static-assembly \
-    && rm static-assembly \
+    && tar -xf asset-static-assembly.tar.gz \
+    && rm asset-static-assembly.tar.gz \
     && mv static/* . \
     && rm -rf static \
     && mv ide-projector-launcher.sh ide/bin \

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ the predefined IDE packaging from the default configuration.
 
 Options:
   -t, --tag string              Name and optionally a tag in the 'name:tag' format for the result image
-  -u, --url string              Downloadable URL of IntelliJ-based IDE package
+  -u, --url string              Downloadable URL of IntelliJ-based IDE package, should be a tar.gz archive
       --run-on-build            Run the container immediately after build
       --save-on-build           Save the image to a tar archive after build. Basename of --url.
       --mount-volumes [string]  Mount volumes to the container which was started using '--run-on-build' option

--- a/projector.sh
+++ b/projector.sh
@@ -25,9 +25,9 @@ RUN_ON_BUILD=false
 SAVE_ON_BUILD=false
 SAVE_ON_BUILD_DIRECTORY="$BUILD_DIRECTORY"/docker
 IDE_PACKAGING_DIRECTORY="$BUILD_DIRECTORY"/ide
-CURRENT_IDE_PACKAGING_SYMLINK="$base_dir"/ide-packaging
-CURRENT_PROJECTOR_ASSEMBLY_SYMLINK="$base_dir"/projector-server-assembly
-CURRENT_PROJECTOR_STATIC_ASSEMBLY="$base_dir"/static-assembly
+CURRENT_IDE_PACKAGING_SYMLINK="$base_dir"/asset-ide-packaging.tar.gz
+CURRENT_PROJECTOR_ASSEMBLY_SYMLINK="$base_dir"/asset-projector-server-assembly.zip
+CURRENT_PROJECTOR_STATIC_ASSEMBLY="$base_dir"/asset-static-assembly.tar.gz
 PROGRESS=auto
 CONFIG_JSON=compatible-ide.json
 CONFIG_JSON_PATH="$base_dir"/"$CONFIG_JSON"
@@ -89,7 +89,7 @@ the predefined IDE packaging from the default configuration.
 
 Options:
   -t, --tag string              Name and optionally a tag in the 'name:tag' format for the result image
-  -u, --url string              Downloadable URL of IntelliJ-based IDE package
+  -u, --url string              Downloadable URL of IntelliJ-based IDE package, should be a tar.gz archive
       --run-on-build            Run the container immediately after build
       --save-on-build           Save the image to a tar archive after build. Basename of --url.
       --mount-volumes [string]  Mount volumes to the container which was started using '--run-on-build' option


### PR DESCRIPTION
According to Brew conventions, assets that provides with `$ rhpkg new-sources ...` should have prefix `asset-` and file extensions. To avoid complicated build flow, changes proposed to make in upstream repository instead midstream.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>