### PR TITLE
Add support for s390x and ppc64le platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,8 @@ ENV PROJECTOR_DIR /projector
 ENV HOME /home/$PROJECTOR_USER_NAME
 ENV PROJECTOR_CONFIG_DIR $HOME/.config
 RUN set -ex \
-    && microdnf install -y --nodocs \
-    shadow-utils wget git nss procps findutils which socat jq \
+    && microdnf install -y --nodocs yum \
+    && yum install -y --nodocs shadow-utils wget git nss procps findutils which socat jq \
     # Java 11 support
     java-11-openjdk-devel \
     # Python support
@@ -75,11 +75,17 @@ RUN set -ex \
     # Packages needed for AWT.
     libXext libXrender libXtst libXi libX11-xcb mesa-libgbm libdrm freetype \
     # Install libsecret for the particular platform
-    && { [ $(uname -m) == "s390x" ] && yum install -y --nodocs \
-        https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-0.20.4-2.fc34.s390x.rpm \
-        https://rpmfind.net/linux/fedora-secondary/development/rawhide/Everything/s390x/os/Packages/l/libsecret-devel-0.20.4-3.fc35.s390x.rpm || true; } \
-    && { [ $(uname -m) == "ppc64le" ] && yum install -y --nodocs libsecret https://rpmfind.net/linux/centos/8-stream/BaseOS/ppc64le/os/Packages/libsecret-devel-0.18.6-1.el8.ppc64le.rpm || true; } \
-    && { [ $(uname -m) == "x86_64" ] && yum install -y --nodocs libsecret || true; } \
+    && if [ $(uname -m) == "s390x" ]; then \
+         yum install -y --nodocs \
+           https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-0.20.4-2.fc34.s390x.rpm \
+           https://rpmfind.net/linux/fedora-secondary/development/rawhide/Everything/s390x/os/Packages/l/libsecret-devel-0.20.4-3.fc35.s390x.rpm; \
+       elif [ $(uname -m) == "ppc64le" ]; then \
+         yum install -y --nodocs \
+           libsecret \
+           https://rpmfind.net/linux/centos/8-stream/BaseOS/ppc64le/os/Packages/libsecret-devel-0.18.6-1.el8.ppc64le.rpm; \
+       elif [ $(uname -m) == "x86_64" ]; then \
+         yum install -y --nodocs libsecret; \
+       fi \
     && adduser -r -u 1002 -G root -d $HOME -m -s /bin/sh $PROJECTOR_USER_NAME \
     && echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
     && mkdir /projects \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN set -ex \
     python2 python39 \
     # Packages needed for AWT.
     libXext libXrender libXtst libXi libX11-xcb mesa-libgbm libdrm freetype \
-    # Install libsecret for the particular platform
+    # Install platform specific libs
     && if [ $(uname -m) == "s390x" ]; then \
          yum install -y --nodocs \
            https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-0.20.4-2.fc34.s390x.rpm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,15 +67,19 @@ ENV HOME /home/$PROJECTOR_USER_NAME
 ENV PROJECTOR_CONFIG_DIR $HOME/.config
 RUN set -ex \
     && microdnf install -y --nodocs \
-    shadow-utils wget git nss procps findutils which socat \
-    # Packages required by JetBrains products.
-    libsecret jq \
+    shadow-utils wget git nss procps findutils which socat jq \
     # Java 11 support
     java-11-openjdk-devel \
     # Python support
     python2 python39 \
     # Packages needed for AWT.
     libXext libXrender libXtst libXi libX11-xcb mesa-libgbm libdrm freetype \
+    # Install libsecret for the particular platform
+    && { [ $(uname -m) == "s390x" ] && yum install -y --nodocs \
+        https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-0.20.4-2.fc34.s390x.rpm \
+        https://rpmfind.net/linux/fedora-secondary/development/rawhide/Everything/s390x/os/Packages/l/libsecret-devel-0.20.4-3.fc35.s390x.rpm || true; } \
+    && { [ $(uname -m) == "ppc64le" ] && yum install -y --nodocs libsecret https://rpmfind.net/linux/centos/8-stream/BaseOS/ppc64le/os/Packages/libsecret-devel-0.18.6-1.el8.ppc64le.rpm || true; } \
+    && { [ $(uname -m) == "x86_64" ] && yum install -y --nodocs libsecret || true; } \
     && adduser -r -u 1002 -G root -d $HOME -m -s /bin/sh $PROJECTOR_USER_NAME \
     && echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
     && mkdir /projects \


### PR DESCRIPTION
ppc64le and s390x platforms require different rpm of `libsecret` and `libsecret-devel`.

The same approach as applied to `theia` container which based on `ubi`. 

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>