### PR TITLE
Provide user to passwd and group file

### DIFF
--- a/static/entrypoint-volume.sh
+++ b/static/entrypoint-volume.sh
@@ -8,6 +8,14 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+# Add current (arbitrary) user to /etc/passwd and /etc/group
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+  fi
+fi
+
 # necessary environment variable: PROJECTOR_ASSEMBLY_DIR
 if [ -n "$PROJECTOR_ASSEMBLY_DIR" ]; then
   cd "$PROJECTOR_ASSEMBLY_DIR"/ide/bin || exit


### PR DESCRIPTION
Current changes proposal adds current user to `/etc/passwd` and `/etc/group` files.

Missing of this configuration cause the problem, when:
```
System.getProperty("user.home");
```
returns `?` value instead of `$HOME`

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>