### PR TITLE
Persist Java preferences folder

### DIFF
--- a/devfiles/latest/che-idea/latest.yaml
+++ b/devfiles/latest/che-idea/latest.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/latest/che-pycharm/latest.yaml
+++ b/devfiles/latest/che-pycharm/latest.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/next/che-idea/2020.3.1-next.yaml
+++ b/devfiles/next/che-idea/2020.3.1-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/next/che-idea/2020.3.2-next.yaml
+++ b/devfiles/next/che-idea/2020.3.2-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/next/che-idea/2020.3.3-next.yaml
+++ b/devfiles/next/che-idea/2020.3.3-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/next/che-idea/2020.3.4-next.yaml
+++ b/devfiles/next/che-idea/2020.3.4-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/next/che-pycharm/2020.3-next.yaml
+++ b/devfiles/next/che-pycharm/2020.3-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/next/che-pycharm/2020.3.1-next.yaml
+++ b/devfiles/next/che-pycharm/2020.3.1-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/next/che-pycharm/2020.3.2-next.yaml
+++ b/devfiles/next/che-pycharm/2020.3.2-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/next/che-pycharm/2020.3.3-next.yaml
+++ b/devfiles/next/che-pycharm/2020.3.3-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/next/che-pycharm/2020.3.4-next.yaml
+++ b/devfiles/next/che-pycharm/2020.3.4-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/next/che-pycharm/2020.3.5-next.yaml
+++ b/devfiles/next/che-pycharm/2020.3.5-next.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/released/che-idea/2020.3.1.yaml
+++ b/devfiles/released/che-idea/2020.3.1.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/released/che-idea/2020.3.2.yaml
+++ b/devfiles/released/che-idea/2020.3.2.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/released/che-idea/2020.3.3.yaml
+++ b/devfiles/released/che-idea/2020.3.3.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/released/che-idea/2020.3.4.yaml
+++ b/devfiles/released/che-idea/2020.3.4.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-idea-injector
     container:

--- a/devfiles/released/che-pycharm/2020.3.1.yaml
+++ b/devfiles/released/che-pycharm/2020.3.1.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/released/che-pycharm/2020.3.2.yaml
+++ b/devfiles/released/che-pycharm/2020.3.2.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/released/che-pycharm/2020.3.3.yaml
+++ b/devfiles/released/che-pycharm/2020.3.3.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/released/che-pycharm/2020.3.4.yaml
+++ b/devfiles/released/che-pycharm/2020.3.4.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/released/che-pycharm/2020.3.5.yaml
+++ b/devfiles/released/che-pycharm/2020.3.5.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:

--- a/devfiles/released/che-pycharm/2020.3.yaml
+++ b/devfiles/released/che-pycharm/2020.3.yaml
@@ -24,6 +24,8 @@ components:
           path: /projector
         - name: projector-configuration
           path: /home/user/.jetbrains
+        - name: projector-java-configuration
+          path: /home/user/.java
       memoryLimit: 6144Mi
       memoryRequest: 2048Mi
       cpuLimit: 2000m
@@ -46,6 +48,8 @@ components:
   - name: projector-volume
     volume: { }
   - name: projector-configuration
+    volume: { }
+  - name: projector-java-configuration
     volume: { }
   - name: che-pycharm-injector
     container:


### PR DESCRIPTION
This changes proposal adds additional volume mount to persist `/home/user/.java` folder which is responsible for storing system Java preferences.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

Fixes https://github.com/eclipse/che/issues/21116