### PR TITLE
Add /projects to a trusted paths configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,7 @@ RUN tar -xf asset-static-assembly.tar.gz && rm asset-static-assembly.tar.gz && \
     chown -R 0:0 static && \
     mv static/* . && rm -rf static && \
     chmod +x *.sh && \
-    mv ide-projector-launcher.sh ide/bin && \
-    mv config ide/
+    mv ide-projector-launcher.sh ide/bin
 
 COPY --from=devfile-plugin-builder --chown=0:0 /devfile-plugin /mnt/rootfs/projector/ide/plugins/devfile-plugin
 

--- a/static/config/options/colors.scheme.xml
+++ b/static/config/options/colors.scheme.xml
@@ -1,5 +1,0 @@
-<application>
-  <component name="EditorColorsManagerImpl">
-    <global_color_scheme name="Darcula"/>
-  </component>
-</application>

--- a/static/config/options/ide.general.xml
+++ b/static/config/options/ide.general.xml
@@ -1,7 +1,0 @@
-<application>
-  <component name="GeneralSettings">
-    <option name="defaultProjectDirectory" value="/projects" />
-    <option name="autoSaveIfInactive" value="true" />
-    <option name="inactiveTimeout" value="5" />
-  </component>
-</application>

--- a/static/config/options/laf.xml
+++ b/static/config/options/laf.xml
@@ -1,5 +1,0 @@
-<application>
-  <component name="LafManager">
-    <laf class-name="com.intellij.ide.ui.laf.darcula.DarculaLaf"/>
-  </component>
-</application>

--- a/static/config/options/other.xml
+++ b/static/config/options/other.xml
@@ -1,7 +1,0 @@
-<application>
-  <component name="PropertiesComponent">
-    <property name="last_opened_file_path" value="/projects" />
-    <property name="terminalCustomCommandExecutionTurnOff" value="false" />
-    <property name="ide.memory.adjusted" value="true"/>
-  </component>
-</application>

--- a/static/config/options/path.macros.xml
+++ b/static/config/options/path.macros.xml
@@ -1,6 +1,0 @@
-<application>
-  <component name="PathMacrosImpl">
-    <macro name="KOTLIN_BUNDLED" value="/projector/ide/plugins/Kotlin/kotlinc"/>
-    <macro name="MAVEN_REPOSITORY" value="/home/projector-user/.m2/repository"/>
-  </component>
-</application>

--- a/static/config/options/ui.lnf.xml
+++ b/static/config/options/ui.lnf.xml
@@ -1,5 +1,0 @@
-<application>
-  <component name="UISettings">
-    <option name="smoothScrolling" value="false"/>
-  </component>
-</application>

--- a/static/config/options/updates.xml
+++ b/static/config/options/updates.xml
@@ -1,5 +1,0 @@
-<application>
-  <component name="UpdatesConfigurable">
-    <option name="CHECK_NEEDED" value="false" />
-  </component>
-</application>

--- a/static/default-configuration-provider.sh
+++ b/static/default-configuration-provider.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+CONFIG_OPTIONS_DIR="$PROJECTOR_CONFIG_DIR/config/options"
+
+COLORS_SCHEME_XML_PATH="$CONFIG_OPTIONS_DIR/colors.scheme.xml"
+read -r -d '' COLORS_SCHEME_XML <<-EOM
+<application>
+  <component name="EditorColorsManagerImpl">
+    <global_color_scheme name="Darcula"/>
+  </component>
+</application>
+EOM
+
+IDE_GENERAL_XML_PATH="$CONFIG_OPTIONS_DIR/ide.general.xml"
+read -r -d '' IDE_GENERAL_XML <<-EOM
+<application>
+  <component name="GeneralSettings">
+    <option name="defaultProjectDirectory" value="$PROJECTS_ROOT" />
+    <option name="autoSaveIfInactive" value="true" />
+    <option name="inactiveTimeout" value="5" />
+  </component>
+</application>
+EOM
+
+LAF_XML_PATH="$CONFIG_OPTIONS_DIR/laf.xml"
+read -r -d '' LAF_XML <<-EOM
+<application>
+  <component name="LafManager">
+    <laf class-name="com.intellij.ide.ui.laf.darcula.DarculaLaf"/>
+  </component>
+</application>
+EOM
+
+OTHER_XML_PATH="$CONFIG_OPTIONS_DIR/other.xml"
+read -r -d '' OTHER_XML <<-EOM
+<application>
+  <component name="PropertiesComponent">
+    <property name="last_opened_file_path" value="$PROJECTS_ROOT" />
+    <property name="terminalCustomCommandExecutionTurnOff" value="false" />
+    <property name="ide.memory.adjusted" value="true"/>
+  </component>
+</application>
+EOM
+
+PATH_MACROS_XML_PATH="$CONFIG_OPTIONS_DIR/path.macros.xml"
+read -r -d '' PATH_MACROS_XML <<-EOM
+<application>
+  <component name="PathMacrosImpl">
+    <macro name="KOTLIN_BUNDLED" value="$PROJECTOR_ASSEMBLY_DIR/ide/plugins/Kotlin/kotlinc"/>
+    <macro name="MAVEN_REPOSITORY" value="$PROJECTOR_CONFIG_DIR/.m2/repository"/>
+  </component>
+</application>
+EOM
+
+TRUSTED_PATHS_XML_PATH="$CONFIG_OPTIONS_DIR/trusted-paths.xml"
+read -r -d '' TRUSTED_PATHS_XML <<-EOM
+<application>
+    <component name="Trusted.Paths.Settings">
+        <option name="TRUSTED_PATHS">
+            <list>
+                <option value="$PROJECTS_ROOT" />
+            </list>
+        </option>
+    </component>
+</application>
+EOM
+
+UI_INF_XML_PATH="$CONFIG_OPTIONS_DIR/ui.lnf.xml"
+read -r -d '' UI_INF_XML <<-EOM
+<application>
+  <component name="UISettings">
+    <option name="smoothScrolling" value="false"/>
+  </component>
+</application>
+EOM
+
+UPDATES_XML_PATH="$CONFIG_OPTIONS_DIR/updates.xml"
+read -r -d '' UPDATES_XML <<-EOM
+<application>
+  <component name="UpdatesConfigurable">
+    <option name="CHECK_NEEDED" value="false" />
+  </component>
+</application>
+EOM
+
+createConfigFiles() {
+  mkdir -p "$CONFIG_OPTIONS_DIR"
+
+  echo "Creating '$COLORS_SCHEME_XML_PATH'"
+  echo "$COLORS_SCHEME_XML" > "$COLORS_SCHEME_XML_PATH"
+
+  echo "Creating '$IDE_GENERAL_XML_PATH'"
+  echo "$IDE_GENERAL_XML" > "$IDE_GENERAL_XML_PATH"
+
+  echo "Creating '$LAF_XML_PATH'"
+  echo "$LAF_XML" > "$LAF_XML_PATH"
+
+  echo "Creating '$OTHER_XML_PATH'"
+  echo "$OTHER_XML" > "$OTHER_XML_PATH"
+
+  echo "Creating '$PATH_MACROS_XML_PATH'"
+  echo "$PATH_MACROS_XML" > "$PATH_MACROS_XML_PATH"
+
+  echo "Creating '$TRUSTED_PATHS_XML_PATH'"
+  echo "$TRUSTED_PATHS_XML" > "$TRUSTED_PATHS_XML_PATH"
+
+  echo "Creating '$UI_INF_XML_PATH'"
+  echo "$UI_INF_XML" > "$UI_INF_XML_PATH"
+
+  echo "Creating '$UPDATES_XML_PATH'"
+  echo "$UPDATES_XML" > "$UPDATES_XML_PATH"
+}
+
+# copy default configuration if it doesn't exist
+if [ ! -d "$PROJECTOR_CONFIG_DIR" ]; then
+  mkdir -p "$PROJECTOR_CONFIG_DIR"
+  createConfigFiles
+elif [ -z "$(ls -A -- "$PROJECTOR_CONFIG_DIR")" ]; then
+  echo "Configuration directory '$PROJECTOR_CONFIG_DIR' is empty."
+  createConfigFiles
+fi
+
+# overwrite default configuration paths for IDE
+cat <<EOT >> "$PROJECTOR_ASSEMBLY_DIR"/ide/bin/idea.properties
+idea.config.path=$PROJECTOR_CONFIG_DIR/config
+idea.system.path=$PROJECTOR_CONFIG_DIR/caches
+idea.plugins.path=$PROJECTOR_CONFIG_DIR/plugins
+idea.log.path=$PROJECTOR_CONFIG_DIR/logs
+EOT

--- a/static/ide-projector-launcher.sh
+++ b/static/ide-projector-launcher.sh
@@ -24,24 +24,7 @@
 # limitations under the License.
 #
 
-# copy default configuration if it doesn't exist
-if [ ! -d "$PROJECTOR_CONFIG_DIR" ]; then
-  echo "Copying default configuration '$PROJECTOR_ASSEMBLY_DIR/ide/config' to '$PROJECTOR_CONFIG_DIR'."
-  mkdir -p "$PROJECTOR_CONFIG_DIR"
-  cp -rp "$PROJECTOR_ASSEMBLY_DIR"/ide/config "$PROJECTOR_CONFIG_DIR"/
-elif [ -z "$(ls -A -- "$PROJECTOR_CONFIG_DIR")" ]; then
-  echo "Configuration directory '$PROJECTOR_CONFIG_DIR' is empty."
-  echo "Copying default configuration '$PROJECTOR_ASSEMBLY_DIR/ide/config' to '$PROJECTOR_CONFIG_DIR'."
-  cp -rp "$PROJECTOR_ASSEMBLY_DIR"/ide/config "$PROJECTOR_CONFIG_DIR"/
-fi
-
-# overwrite default configuration paths for IDE
-cat <<EOT >> "$PROJECTOR_ASSEMBLY_DIR"/ide/bin/idea.properties
-idea.config.path=$PROJECTOR_CONFIG_DIR/config
-idea.system.path=$PROJECTOR_CONFIG_DIR/caches
-idea.plugins.path=$PROJECTOR_CONFIG_DIR/plugins
-idea.log.path=$PROJECTOR_CONFIG_DIR/logs
-EOT
+bash "$PROJECTOR_ASSEMBLY_DIR"/default-configuration-provider.sh
 
 # provide necessary environment variables
 echo "export JAVA_HOME=/usr/lib/jvm/java-11" >> "${HOME}"/.bashrc


### PR DESCRIPTION
This changes proposal adds default configuration for trusted paths. That contains `/projects`. To avoid showing the additional dialogs for end user after workspace startup.

fixes https://github.com/eclipse/che/issues/21110

To check the changes it is enough to create the workspace from https://github.com/vzhukovs/che-21029
This is Gradle project and after workspace startup the dialog:

![image](https://user-images.githubusercontent.com/1636395/152516370-1d3109b8-d0ac-47ec-acb2-1cc404b0cf4d.png)

should not appear.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>