### PR TITLE
Use PROJECT_SOURCE as default working directory

### DIFF
--- a/plugins/devfile-plugin/src/main/kotlin/che/incubator/devfile/DevfileRunConfiguration.kt
+++ b/plugins/devfile-plugin/src/main/kotlin/che/incubator/devfile/DevfileRunConfiguration.kt
@@ -26,6 +26,10 @@ class DevfileRunConfiguration(project: Project, factory: ConfigurationFactory, n
     var runId = ""
     var scriptText = ""
     var workingDir = ""
+        get() = field.ifEmpty { "\${PROJECT_SOURCE}" }
+        set(value) {
+            value.ifEmpty { "\${PROJECT_SOURCE}" }.also { field = it }
+        }
     var environment: EnvironmentVariablesData = EnvironmentVariablesData.DEFAULT
 
     override fun getState(executor: Executor, environment: ExecutionEnvironment): RunProfileState {


### PR DESCRIPTION
This changes proposal provides `PROJECT_SOURCE` directory as default working directory if it omitted in Devfile command.

To test the changes create the workspace from: https://github.com/vzhukovs/demo-repository/tree/che-21100
Devfile command `command-without-working-dir` should be executed in `PROJECT_SOURCE` directory.

fixes https://github.com/eclipse/che/issues/21100

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>