### PR TITLE
Publish next tag for latest dev image

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -45,6 +45,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - name: Compute sha revision
+        id: short_sha
+        run: echo ::set-output name=hash::$(git rev-parse --short "$GITHUB_SHA")
       - name: Docker login
         uses: docker/login-action@v1
         with:
@@ -58,4 +61,15 @@ jobs:
               --url ${{ matrix.downloadUrl }} \
               --progress plain \
               --log-level debug
+          # publish `repo/name:version-next`
           docker push ${{ secrets.QUAY_REPOSITORY }}/${{ matrix.dockerImage }}:${{ matrix.version }}-next
+          
+          # publish `repo/name:version-shortSha`
+          docker tag ${{ secrets.QUAY_REPOSITORY }}/${{ matrix.dockerImage }}:${{ matrix.version }}-next ${{ secrets.QUAY_REPOSITORY }}/${{ matrix.dockerImage }}:${{ matrix.version }}-${{ steps.short_sha.outputs.hash }}
+          docker push ${{ secrets.QUAY_REPOSITORY }}/${{ matrix.dockerImage }}:${{ matrix.version }}-${{ steps.short_sha.outputs.hash }}
+          
+          # publish `repo/name:next`
+          if [ ${{ matrix.latest }} == true ]; then
+            docker tag ${{ secrets.QUAY_REPOSITORY }}/${{ matrix.dockerImage }}:${{ matrix.version }}-next ${{ secrets.QUAY_REPOSITORY }}/${{ matrix.dockerImage }}:next
+            docker push ${{ secrets.QUAY_REPOSITORY }}/${{ matrix.dockerImage }}:next
+          fi


### PR DESCRIPTION
Publish developer images based on the latest commit in `main` branch:

- `<image>:next`
- `<image>:<version>-next`
- `<image>:<version>-<short_sha>`

fixes https://github.com/eclipse/che/issues/21031

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>