### PR TITLE
Fix "busy resource" error for brew build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN for f in "/mnt/rootfs/bin/" "/mnt/rootfs/home/projector" "/mnt/rootfs/etc/pa
            chmod -R g+rwX ${f}; \
     done
 
+RUN rm /mnt/rootfs/etc/hosts
 
 # Stage 2. Copy from build environment Projector assembly to the runtime. Projector runs in headless mode.
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal


### PR DESCRIPTION
Backport of https://github.com/che-incubator/jetbrains-editor-images/commit/36bbcf6619232f2bf1a8fb05f86e6286de1938b6 to main branch.

Part of https://issues.redhat.com/browse/CRW-2736

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>