### PR TITLE
Update ubi-builder image base version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@
 #       * asset-projector-server-assembly.zip - Projector Server assembly;
 #       * asset-static-assembly.tar.gz - archived `static/` directory.
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8
-FROM registry.access.redhat.com/ubi8/ubi:8.5-214 as ubi-builder
+FROM registry.access.redhat.com/ubi8/ubi:8.5-239.1651231664 as ubi-builder
 COPY --chown=0:0 asset-required-rpms.txt /tmp/asset-required-rpms.txt
 
 RUN mkdir -p /mnt/rootfs


### PR DESCRIPTION
Update ubi8 image version from 8.5-214 to 8.5-239.1651231664 to fix JDK related CVEs.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>