### PR TITLE
Update endpoint-redirect name to be consistent with JetBrains-based IDEs

### DIFF
--- a/che-plugin/src/main/kotlin/io/github/che_incubator/plugin/endpoint/EndpointUtil.kt
+++ b/che-plugin/src/main/kotlin/io/github/che_incubator/plugin/endpoint/EndpointUtil.kt
@@ -36,7 +36,7 @@ fun isPublicDevfilePortOffline(endpoint: Endpoint?): Boolean {
 }
 
 fun isNameStartsFromRedirectPattern(name: String): Boolean {
-    return name.startsWith("code-redirect-")
+    return name.startsWith("intellij-redirect-")
 }
 
 fun isPathNullOrEmpty(path: String?): Boolean {

--- a/devfiles/latest/che-idea/latest.yaml
+++ b/devfiles/latest/che-idea/latest.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/latest/che-pycharm/latest.yaml
+++ b/devfiles/latest/che-pycharm/latest.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-idea/2020.3-next.yaml
+++ b/devfiles/next/che-idea/2020.3-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-idea/2021.1-next.yaml
+++ b/devfiles/next/che-idea/2021.1-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-idea/2021.2-next.yaml
+++ b/devfiles/next/che-idea/2021.2-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-idea/2021.3-next.yaml
+++ b/devfiles/next/che-idea/2021.3-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-idea/2022.1-next.yaml
+++ b/devfiles/next/che-idea/2022.1-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-pycharm/2020.3-next.yaml
+++ b/devfiles/next/che-pycharm/2020.3-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-pycharm/2021.1-next.yaml
+++ b/devfiles/next/che-pycharm/2021.1-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-pycharm/2021.2-next.yaml
+++ b/devfiles/next/che-pycharm/2021.2-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-pycharm/2021.3-next.yaml
+++ b/devfiles/next/che-pycharm/2021.3-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/next/che-pycharm/2022.1-next.yaml
+++ b/devfiles/next/che-pycharm/2022.1-next.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-idea/2020.3.yaml
+++ b/devfiles/released/che-idea/2020.3.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-idea/2021.1.yaml
+++ b/devfiles/released/che-idea/2021.1.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-idea/2021.2.yaml
+++ b/devfiles/released/che-idea/2021.2.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-idea/2021.3.yaml
+++ b/devfiles/released/che-idea/2021.3.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-idea/2022.1.yaml
+++ b/devfiles/released/che-idea/2022.1.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-pycharm/2020.3.yaml
+++ b/devfiles/released/che-pycharm/2020.3.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-pycharm/2021.1.yaml
+++ b/devfiles/released/che-pycharm/2021.1.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-pycharm/2021.2.yaml
+++ b/devfiles/released/che-pycharm/2021.2.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-pycharm/2021.3.yaml
+++ b/devfiles/released/che-pycharm/2021.3.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http

--- a/devfiles/released/che-pycharm/2022.1.yaml
+++ b/devfiles/released/che-pycharm/2022.1.yaml
@@ -42,21 +42,21 @@ components:
           path: '/?backgroundColor=434343&wss'
           secure: false
           protocol: http
-        - name: code-redirect-1
+        - name: intellij-redirect-1
           targetPort: 13131
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-2
+        - name: intellij-redirect-2
           targetPort: 13132
           exposure: public
           protocol: http
           attributes:
             discoverable: false
             urlRewriteSupported: true
-        - name: code-redirect-3
+        - name: intellij-redirect-3
           targetPort: 13133
           exposure: public
           protocol: http


### PR DESCRIPTION
Update redirect endpoint names from `code-redirect-*` to `intellij-redirect-*`

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>