### PR TITLE
fix: Add 'execute' permission for the machine-exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN unzip asset-che-plugin-assembly.zip && rm asset-che-plugin-assembly.zip && \
     find . -maxdepth 1 -type d -name che-plugin -exec mv {} ide/plugins/che-plugin \;
 
 COPY --chown=0:0 asset-machine-exec ide/bin/machine-exec
+RUN chmod +x ide/bin/machine-exec
 
 RUN for f in "/mnt/rootfs/bin/" "/mnt/rootfs/home/projector" "/mnt/rootfs/etc/passwd" "/mnt/rootfs/etc/group" "/mnt/rootfs/projects" "/mnt/rootfs/projector/ide/bin" ; do\
            chgrp -R 0 ${f} && \


### PR DESCRIPTION
Productization process for the `Red Hat OpenShift Dev Spaces - IntelliJ IDEA Community IDE container` includes some steps like `prepare assets`, `push assets` to a remote resource, `pull assets`.
`machine-exec` loses permissions on some step (I guess the cause of the problem - `push assets` then `pull assets`).

My propose is - adding `execute` permission for the `machine-exec` directly in the `Dockerfile` - so we don't depend on the steps in the productization process.  

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>