### PR TITLE
fix: move java home initialization only for local container

### DIFF
--- a/static/entrypoint.sh
+++ b/static/entrypoint.sh
@@ -16,6 +16,9 @@ if ! whoami &> /dev/null; then
   fi
 fi
 
+# provide necessary environment variables
+echo "export JAVA_HOME=/usr/lib/jvm/java-11" >> "${HOME}"/.bashrc
+
 # PROJECTOR_ASSEMBLY_DIR env variable provided by Docker environment
 cd "$PROJECTOR_ASSEMBLY_DIR"/ide/bin || exit
 

--- a/static/ide-projector-launcher.sh
+++ b/static/ide-projector-launcher.sh
@@ -26,9 +26,6 @@
 
 bash "$PROJECTOR_ASSEMBLY_DIR"/default-configuration-provider.sh
 
-# provide necessary environment variables
-echo "export JAVA_HOME=/usr/lib/jvm/java-11" >> "${HOME}"/.bashrc
-
 # offline activation key registration
 # depending on the product code id taken from $PROJECTOR_ASSEMBLY_DIR/ide/product-info.json looks for:
 #   /tmp/idea.key


### PR DESCRIPTION
Move initialization of `JAVA_HOME` environment variable from main IDE launcher to local `entrypoint.sh` which is supposed to be run only on the local host. If IDE launches in different container, there might be different jdk configuration, so it can be overwritten.