### PR TITLE
chore: update che-api version

### DIFF
--- a/che-plugin/build.gradle.kts
+++ b/che-plugin/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation("org.eclipse.jetty.websocket:websocket-jetty-client:11.0.9")
     implementation("com.google.code.gson:gson:2.9.0")
-    implementation("io.github.che-incubator:che-api:1.0")
+    implementation("io.github.che-incubator:che-api:1.1")
 }
 
 


### PR DESCRIPTION
Provides update for `che-api` artifact which brings the new version of snakeyaml (1.30 -> 1.33).

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>