### PR TITLE
Remove redundant usage of the secret

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Docker image build
         run: |
           ./projector.sh build \
-              --tag ${{ secrets.QUAY_REPOSITORY }}/${{ matrix.dockerImage }}:${{ matrix.version }} \
+              --tag ${{ matrix.dockerImage }}:${{ matrix.version }} \
               --url ${{ matrix.downloadUrl }} \
               --progress plain \
               --log-level debug


### PR DESCRIPTION
The PR removes redundant usage of `${{ secrets.QUAY_REPOSITORY }}`.
On some PRs, it's empty, e.g. https://github.com/che-incubator/jetbrains-editor-images/actions/runs/3842562772/jobs/6663407295