### PR TITLE
Updates to the developer guide

### DIFF
--- a/doc/Developer-Guide.md
+++ b/doc/Developer-Guide.md
@@ -198,7 +198,7 @@ JetBrains provides zip archive with two types of activation code. `<License ID> 
 
 ### Use activation codes when running a JetBrains IDE container using Docker
 
-When you run the container on your local machine, it is possible to provide the activation code for offline usage to register the JetBrains IDE. The container image contains scripts, which perform this operation. You only need to map the activation code, that are located on your host, as volume mounts when running the container with Docker. For example:
+When you run the container on your local machine, it is possible to provide the activation code for offline usage to register the JetBrains IDE. The container image contains scripts, which perform this operation. You only need to map the activation codes, that are located on your host, as volume mounts when running the container with Docker. For example:
 
 ```sh
 $ docker run --env DEV_MODE=true --rm -p 8887:8887 -v <path to text file on your host>:/tmp/<product>.key -it <containerName>

--- a/doc/Developer-Guide.md
+++ b/doc/Developer-Guide.md
@@ -4,7 +4,7 @@ Current document contains tip to help and understand the first steps that needed
 
 ## Prerequisities
 
-In order to build locally container images, make sure, that **Docker version is 18.09** or higher, since the build scripts use [Docker BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).
+In order to build the container images locally, make sure, that **Docker version is 18.09** or higher, since the build scripts use [Docker BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).
 
 > For macOS users, it is needed to ensure that `gnu-getopt` is installed in the system.
 

--- a/doc/Developer-Guide.md
+++ b/doc/Developer-Guide.md
@@ -2,19 +2,17 @@
 
 Current document contains tip to help and understand the first steps that needed to be performed to build custom images with different JetBrains IDEs.
 
-
-
 ## Prerequisities
 
-In order to build locally Docker container, make sure, that **Docker version is 18.09** or higher, since the build scripts use [Docker BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).
+In order to build locally container images, make sure, that **Docker version is 18.09** or higher, since the build scripts use [Docker BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).
 
 > For macOS users, it is needed to ensure that `gnu-getopt` is installed in the system.
 
 
 
-## Build JetBrains IDE in Docker using custom distribution
+## Build JetBrains IDE container image using custom distribution and run it using Docker
 
-In order to build the Docker image with the custom JetBrains IDE distribution, there is an ability to pass particular distribution through the `--tag` and `--url` parameters to `./projector.sh build`.
+In order to build the container image with the custom JetBrains IDE distribution, there is an ability to pass particular distribution through the `--tag` and `--url` parameters to `./projector.sh build`.
 
 The complete command looks:
 
@@ -38,7 +36,7 @@ After that, navigate to [http://localhost:8887](http://localhost:8887), to acces
 
 Below you can find a few examples how to build different JetBrains IDEs using `--url` parameter:
 
-- Build the Docker image with **WebStorm 2020.3.3**
+- Build the container image with **WebStorm 2020.3.3**
 
   ```sh
   $ git clone https://github.com/che-incubator/jetbrains-editor-images && cd jetbrains-editor-images
@@ -46,7 +44,7 @@ Below you can find a few examples how to build different JetBrains IDEs using `-
   $ ./projector.sh run che-webstorm:latest
   ```
 
-- Build the Docker image with **PyCharm Community 2020.3.5**
+- Build the container image with **PyCharm Community 2020.3.5**
 
   ```sh
   $ git clone https://github.com/che-incubator/jetbrains-editor-images && cd jetbrains-editor-images
@@ -54,7 +52,7 @@ Below you can find a few examples how to build different JetBrains IDEs using `-
   $ ./projector.sh run che-pycharm:latest
   ```
 
-- Build the Docker image with **IntelliJ IDEA Ultimate 2020.2.2**
+- Build the container image with **IntelliJ IDEA Ultimate 2020.2.2**
 
   ```sh
   $ git clone https://github.com/che-incubator/jetbrains-editor-images && cd jetbrains-editor-images
@@ -66,7 +64,7 @@ After performing any build scenario, which provided above, navigate to [http://l
 
 
 
-## Build JetBrains IDE in Docker based on the predefined configuration
+## Build JetBrains IDE container image with the predefined configuration
 
 It is also available to select predefined IDE distribution from the wizard during image build. When `--tag` or `--url` parameters are ommitted, then select wizard is called. Predefined configurations, that are currently supported are provided in [compatible-ide.json](../compatible-ide.json).
 
@@ -95,9 +93,9 @@ Then prompt to choose IDE packaging version to build (in case of selecting defau
 
 
 
-## Use Docker image with JetBrains IDE in Eclipse Che
+## Use JetBrains IDE container image in an Eclipse Che workspace
 
-The next step will be tag the resulting image by adding your namespace using the following command pattern:
+The next step will be tag and push the resulting image by adding your namespace using the following command pattern:
 
 ```sh
 $ docker tag <containerName>:latest <username>/<containerName>:latest
@@ -113,16 +111,7 @@ $ docker push superuser/che-pycharm:latest
 
 > Make sure, that you are logged in using `$ docker login` command to be able to push an image to your namespace.
 
-Now it is possible to use the built image as Che Editor in Eclipse Che. Eclipse Che uses the conception called Developer Workspace, which represents as set of configuration files placed in user's repository. In repository root there should located `devfile.yaml` which provides all necessary information about workspace name, additional projects that needs to be cloned:
-
-```yaml
-schemaVersion: 2.1.0
-metadata:
-  name: <workspace name goes here>
-  namespace: <workspace namespace goes here, usually `admin-che`>
-```
-
-Also to provide the configuration for custom Che Editor there should be directory called `.che` with the file called `che-editor.yaml` which instructs Eclipse Che to load editor configuration from the current configuration file. Bellow you can find an example for Che Editor based on the IntelliJ IDEA Community Edition:
+Now it is possible to use the built image as Che Editor in Eclipse Che. One way to do that is to create a file named `che-editor.yaml` under the folder `.che` in the project repository. Bellow you can find an example for `che-editor.yaml` based on the IntelliJ IDEA Community Edition:
 
 ```yaml
 inline:
@@ -207,9 +196,9 @@ JetBrains provides zip archive with two types of activation code. `<License ID> 
 
 ![activation-code](https://raw.githubusercontent.com/che-incubator/che-editor-intellij-community/media/images/activation-code.jpg)
 
-### Provision activation code to Docker container
+### Use activation codes when running a JetBrains IDE container using Docker
 
-When you run the Docker container on your local machine, it is possible to provide the activation code for offline usage to register the JetBrains IDE. Docker image contains scripts, which perform this operation. The only you need to map the activation code, that locates on your host as volume mount into Docker container, for example:
+When you run the container on your local machine, it is possible to provide the activation code for offline usage to register the JetBrains IDE. The container image contains scripts, which perform this operation. You only need to map the activation code, that are located on your host, as volume mounts when running the container with Docker. For example:
 
 ```sh
 $ docker run --env DEV_MODE=true --rm -p 8887:8887 -v <path to text file on your host>:/tmp/<product>.key -it <containerName>
@@ -223,13 +212,11 @@ Mount path `/tmp/<product>.key` should be used according to the JetBrains produc
 - `/tmp/phpstorm.key`
 - `/tmp/goland.key`
 
+### Use activation codes when running a JetBrains IDE in an Eclipse Che workspace
 
+Since Eclipse Che runs in Kubernetes environment, it is possible to provision the activation code for offline usage with Kubernetes Secrets.
 
-### Provision activation code to Eclipse Che
-
-Since Eclipse Che runs in Kubernetes environment, it is possible to provision the activation code for offline usage throught the Kubernetes Secrets.
-
-> To understand what is Kubernetes Secret and how to operate with the last one, see: [Kubernetes Documentation](https://kubernetes.io/docs/concepts/configuration/secret/)
+> To understand what is a Kubernetes Secret and how to operate it, see: [Kubernetes Documentation](https://kubernetes.io/docs/concepts/configuration/secret/)
 
 Let's create a Kubernetes Secret, that will instruct Eclipse Che to mount the activation code into container which is based on the JetBrains specific product:
 
@@ -239,12 +226,11 @@ kind: Secret
 metadata:
   name: jetbrains-offline-activation-code
   labels:
-    app.kubernetes.io/component: workspace-secret
-    app.kubernetes.io/part-of: che.eclipse.org
+    controller.devfile.io/mount-to-devworkspace: 'true'
+    controller.devfile.io/watch-secret: 'true'
   annotations:
-    che.eclipse.org/automount-workspace-secret: 'false'
-    che.eclipse.org/mount-path: /tmp/
-    che.eclipse.org/mount-as: file
+    controller.devfile.io/mount-path: /tmp/
+    controller.devfile.io/mount-as: file
 data:
   idea.key: <base64 encoded data content here>
   pycharm.key: <base64 encoded data content here>
@@ -252,16 +238,3 @@ data:
   phpstorm.key: <base64 encoded data content here>
   goland.key: <base64 encoded data content here>
 ```
-
-Annotation `automount-workspace-secret` with the `false` value disables the mounting process until it is explicitly requested in a workspace component using the `automountWorkspaceSecrets:true` property. So, to mount the activation codes into a Workspace, workspace configuration should be updated by adding `automountWorkspaceSecrets:true` property:
-
-```yaml
-metadata:
-  name: <workspace name goes here>
-components:
-  - type: cheEditor
-    automountWorkspaceSecrets: true
-    reference: '<url for the below meta.yaml goes here>'
-apiVersion: 1.0.0
-```
-


### PR DESCRIPTION
There is a recurring interest to use "other" JetBrains IDEs with OpenShift Dev Spaces. I have reviewed the developer guide and proposed some updates:
- Update the secret injection labels and annotations [following the new DevWorkspace convention](https://github.com/devfile/devworkspace-operator/blob/main/docs/additional-configuration.adoc#automatically-mounting-volumes-configmaps-and-secrets)
- Don't require a `devfile.yaml` at the root of the repo anymore
- `s/Docker image/container image/g`
