### PR TITLE
Added devfile component and commands

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,0 +1,40 @@
+schemaVersion: 2.2.0
+metadata:
+  name: jetbrains-editor-images
+components:
+  - name: devtools
+    container:
+      image: quay.io/devfile/universal-developer-image:latest
+      cpuLimit: '4'
+      memoryLimit: 12Gi
+      env:
+        - name: DOCKER
+          value: podman
+        - name: KUBEDOCK_ENABLED
+          value: 'true'
+commands:
+  - id: generic-build
+    exec:
+      commandLine: ./projector.sh build
+      component: devtools
+      label: Interactive build of supported JetBrains IDEs
+  - id: goland-build
+    exec:
+      commandLine: ./projector.sh build --url https://download.jetbrains.com/go/goland-2021.3.3.tar.gz --tag quay.io/che-incubator/che-goland:2021.3
+      component: devtools
+      label: Build of JetBrains GoLand container image
+  - id: raider-build
+    exec:
+      commandLine: ./projector.sh build --url https://download.jetbrains.com/rider/JetBrains.Rider-2021.3.3.tar.gz --tag quay.io/che-incubator/che-rider:2021.3
+      component: devtools
+      label: Build of JetBrains Raider container image
+  - id: intellij-ultimate-build
+    exec:
+      commandLine: ./projector.sh build --url https://download.jetbrains.com/idea/ideaIU-2021.3.2.tar.gz --tag quay.io/che-incubator/che-ideaiu:2021.3
+      component: devtools
+      label: Build of JetBrains IntelliJ Ultimate container image
+  - id: intellij-run
+    exec:
+      commandLine: podman run -p 8887:8887 -d quay.io/che-incubator/che-idea:next
+      component: devtools
+      label: Run of JetBrains IntelliJ

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN unzip asset-projector-server-assembly.zip && rm asset-projector-server-assem
     find . -maxdepth 1 -type d -name projector-server-* -exec mv {} ide/projector-server \;
 
 COPY --chown=0:0 asset-static-assembly.tar.gz .
-RUN tar -xf asset-static-assembly.tar.gz && rm asset-static-assembly.tar.gz && \
+RUN tar --no-same-owner -xf asset-static-assembly.tar.gz && rm asset-static-assembly.tar.gz && \
     chown -R 0:0 static && \
     mv static/* . && rm -rf static && \
     chmod +x *.sh && \

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,3 +1,0 @@
-schemaVersion: 2.1.0
-metadata:
-  name: jetbrains-editor-images


### PR DESCRIPTION
Updated the devfile to provide a `cpuLimit: '4'` and `memoryLimit: 12Gi`. Plus commands to:

- `generic-build`: run an interactive build of one of the editors in `compatible-ide.json`
- `goland-build`: run the build of `goland-2021.3.3.tar.gz`
- `raider-build`: run the build of `rider-2021.3.3.tar.gz`
- `intellij-ultimate-build`: run the build `ideaIU-2021.3.2.tar.gz`
- `intellij-run`: run `quay.io/che-incubator/che-idea:next` using podman

<img width="1274" alt="image" src="https://github.com/che-incubator/jetbrains-editor-images/assets/606959/1749aebc-7aa1-47e7-b1c9-798e98fbeed8">
