### PR TITLE
Fix http status 404 from rpmfind.net

### DIFF
--- a/asset-required-rpms.txt
+++ b/asset-required-rpms.txt
@@ -1,1 +1,1 @@
-https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/libsecret-devel-0.18.6-1.el8.x86_64.rpm libsecret
+https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi8/8/x86_64/baseos/os/Packages/l/libsecret-devel-0.18.6-1.el8.x86_64.rpm libsecret


### PR DESCRIPTION
About Changes
===

- changed host of libsecret from `rpmfind.net` to `cdn-redhat.com` to avoid 404 error.

404 Error
===

Building container image FAILED due to 404 error for libsecret from rpmfind.net. The 404 error has happened since Jun 8 2024.

For example, please see the GitHub Actions logs...

- https://github.com/che-incubator/jetbrains-editor-images/actions/runs/10223527657/job/28289983954#step:3:12460
- https://github.com/che-incubator/jetbrains-editor-images/actions/runs/9424485441/job/25964788377#step:3:18589

Test
===

tested with `curl`

![image](https://github.com/user-attachments/assets/79541693-755c-4499-b953-0bfbeef03158)


